### PR TITLE
[feature/network-properties] Add new Network Libraries and tests

### DIFF
--- a/src/Contracts/Network/Libraries/LibraryInterface.php
+++ b/src/Contracts/Network/Libraries/LibraryInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Midnite81\Core\Contracts\Network\Libraries;
+
+use Illuminate\Support\Collection;
+
+interface LibraryInterface
+{
+    /**
+     * Retrieves a dictionary of user agents (value) and their corresponding names (key).
+     *
+     * @return Collection<string, string> A collection of key-value pairs where the key is the user agent name
+     *                                    and the value is the user agent string.
+     */
+    public function dictionary(): Collection;
+}

--- a/src/Network/Libraries/Previewers.php
+++ b/src/Network/Libraries/Previewers.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Midnite81\Core\Network\Libraries;
+
+use Illuminate\Support\Collection;
+use Midnite81\Core\Contracts\Network\Libraries\LibraryInterface;
+
+class Previewers implements LibraryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function dictionary(): Collection
+    {
+        return collect([
+            'Slack' => 'Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)',
+            'Slack.Name' => 'Slackbot-LinkExpanding',
+            'Slack.URL' => 'https://api.slack.com/robots',
+
+            'Twitter' => 'Twitterbot/1.0',
+            'Twitter.Name' => 'Twitterbot',
+
+            'Facebook' => 'facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)',
+            'Facebook.Name' => 'facebookexternalhit',
+            'Facebook.URL' => 'http://www.facebook.com/externalhit_uatext.php',
+
+            'LinkedIn' => 'LinkedInBot/1.0 (compatible; Mozilla/5.0; Jakarta Commons-HttpClient/3.1 +http://www.linkedin.com)',
+            'LinkedIn.Name' => 'LinkedInBot',
+            'LinkedIn.URL' => 'http://www.linkedin.com',
+
+            'Google' => 'Googlebot/2.1 (+http://www.google.com/bot.html)',
+            'Google.Name' => 'Googlebot',
+            'Google.URL' => 'http://www.google.com/bot.html',
+
+            'Google Ads' => 'AdsBot-Google (+http://www.google.com/adsbot.html)',
+            'Google Ads.Name' => 'AdsBot-Google',
+            'Google Ads.URL' => 'http://www.google.com/adsbot.html',
+
+            'Google Ads Mobile' => 'AdsBot-Google-Mobile-Apps',
+            'Google Ads Mobile.Name' => 'AdsBot-Google-Mobile-Apps',
+
+            'Google Ads Partners' => 'Mediapartners-Google',
+            'Google Ads Partners.Name' => 'Mediapartners-Google',
+
+            'Google Ads Images' => 'Googlebot-Image/1.0',
+            'Google Ads Images.Name' => 'Googlebot-Image',
+
+            'Google Ads News' => 'Googlebot-News',
+            'Google Ads News.Name' => 'Googlebot-News',
+
+            'Google Ads Video' => 'Googlebot-Video/1.0',
+            'Google Ads Video.Name' => 'Googlebot-Video',
+
+            'BingBot' => 'Bingbot',
+            'BingBot.Name' => 'Bingbot',
+            'BingBot.URL' => 'https://www.bing.com/webmaster/help/which-crawlers-does-bing-use-8c184ec0',
+
+            'Pinterest' => 'Pinterestbot',
+            'Pinterest.Name' => 'Pinterestbot',
+            'Pinterest.URL' => 'https://developers.pinterest.com/docs/redoc/',
+
+            'Discord' => 'Discordbot',
+            'Discord.Name' => 'Discordbot',
+            'Discord.URL' => 'https://discord.com',
+
+            'Telegram' => 'TelegramBot',
+            'Telegram.URL' => 'https://core.telegram.org/bots',
+
+            'WhatsApp' => 'WhatsApp',
+            'WhatsApp.URL' => 'https://www.whatsapp.com/',
+
+            'Reddit' => 'Redditbot',
+            'Reddit.URL' => 'https://www.reddit.com',
+
+            'Yahoo! Slurp' => 'Yahoo! Slurp',
+            'Yahoo! Slurp.URL' => 'https://help.yahoo.com/kb/SLN22600.html',
+
+            'DuckDuckGo' => 'DuckDuckBot',
+            'DuckDuckGo.URL' => 'https://duckduckgo.com',
+
+            'Slack.Short' => 'Slackbot',
+            'Twitter.Short' => 'Twitterbot',
+            'Facebook.Short' => 'facebookexternalhit',
+            'LinkedIn.Short' => 'LinkedInBot',
+            'Google.Short' => 'Googlebot',
+            'AppleBot.Short' => 'Applebot',
+        ]);
+    }
+}

--- a/src/Network/Libraries/SearchEngines.php
+++ b/src/Network/Libraries/SearchEngines.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Midnite81\Core\Network\Libraries;
+
+use Illuminate\Support\Collection;
+use Midnite81\Core\Contracts\Network\Libraries\LibraryInterface;
+
+class SearchEngines implements LibraryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function dictionary(): Collection
+    {
+        return collect([
+            'Googlebot' => 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+            'Googlebot.Name' => 'Googlebot',
+            'Googlebot.Url' => 'http://www.google.com/bot.html',
+
+            'Bingbot' => 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)',
+            'Bingbot.Name' => 'Bingbot',
+            'Bingbot.Url' => 'http://www.bing.com/bingbot.htm',
+
+            'Yahoo! Slurp' => 'Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)',
+            'Yahoo! Slurp.Name' => 'Yahoo! Slurp',
+            'Yahoo! Slurp.Url' => 'http://help.yahoo.com/help/us/ysearch/slurp',
+
+            'DuckDuckBot' => 'DuckDuckBot/1.0; (+http://duckduckgo.com/duckduckbot.html)',
+            'DuckDuckBot.Name' => 'DuckDuckBot',
+            'DuckDuckBot.Url' => 'http://duckduckgo.com/duckduckbot.html',
+
+            'BaiduSpider' => 'Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)',
+            'BaiduSpider.Name' => 'BaiduSpider',
+            'BaiduSpider.Url' => 'http://www.baidu.com/search/spider.html',
+
+            'YandexBot' => 'Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)',
+            'YandexBot.Name' => 'YandexBot',
+            'YandexBot.Url' => 'http://yandex.com/bots',
+
+            'Sogou Spider' => 'Mozilla/5.0 (compatible; Sogou web spider)',
+            'Sogou Spider.Name' => 'Sogou web spider',
+            'Sogou Spider.Url' => 'http://www.sogou.com/docs/help/webmasters.htm#07',
+
+            'Exabot' => 'Mozilla/5.0 (compatible; Exabot; +http://www.exabot.com/go/robot)',
+            'Exabot.Name' => 'Exabot',
+            'Exabot.Url' => 'http://www.exabot.com/go/robot',
+
+            'SeznamBot' => 'Mozilla/5.0 (compatible; SeznamBot/3.2; +http://napoveda.seznam.cz/en/seznambot-intro/)',
+            'SeznamBot.Name' => 'SeznamBot',
+            'SeznamBot.Url' => 'http://napoveda.seznam.cz/en/seznambot-intro/',
+        ]);
+    }
+}

--- a/src/Network/UserAgentMatcher.php
+++ b/src/Network/UserAgentMatcher.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Midnite81\Core\Network;
+
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use Midnite81\Core\Contracts\Network\Libraries\LibraryInterface;
+
+class UserAgentMatcher
+{
+    /**
+     * Class constructor.
+     *
+     * @param string|null $userAgent Optional user agent string. Defaults to null.
+     * @param array<int, LibraryInterface|class-string> $dictionaries Optional array of dictionaries. Defaults to an
+     *                                                                empty array.
+     * @return void
+     */
+    public function __construct(
+        protected ?string $userAgent = null,
+        protected array $dictionaries = [],
+    ) {
+        if ($userAgent === null) {
+            $this->userAgent = request()->header('User-Agent') ?? null;
+        }
+    }
+
+    /**
+     * Determines if the user agent matches the dictionaries.
+     *
+     * @param bool $exactMatch Whether to perform an exact match or not. Defaults to false.
+     * @param bool $caseSensitive Whether to perform a case-sensitive match. Defaults to false.
+     * @param bool $matchKey Whether to match on keys as well as values. Defaults to false.
+     * @return bool Returns true if a match is found, false otherwise.
+     */
+    public function match(bool $exactMatch = false, bool $caseSensitive = false, bool $matchKey = false): bool
+    {
+        $this->initialise();
+        $convertValue = fn ($value) => $caseSensitive ? $value : strtolower($value);
+        $useragent = $convertValue($this->userAgent);
+
+        foreach ($this->dictionaries as $dictionary) {
+            $dictionaryCollection = $dictionary->dictionary();
+
+            if ($matchKey) {
+                $keyContains = $dictionaryCollection->keys()->contains(function ($key) use (
+                    $caseSensitive,
+                    $convertValue,
+                    $exactMatch,
+                    $useragent
+                ) {
+                    if ($exactMatch) {
+                        return $useragent === $convertValue($key);
+                    }
+
+                    return Str::of($useragent)->contains($convertValue($key), !$caseSensitive);
+                });
+
+                if ($keyContains) {
+                    return true;
+                }
+            }
+
+            $valueContains = $dictionaryCollection->contains(function ($value) use ($caseSensitive, $convertValue, $useragent, $exactMatch) {
+                if ($exactMatch) {
+                    return $useragent === $convertValue($value);
+                }
+
+                return Str::of($useragent)->contains($convertValue($value), !$caseSensitive);
+            });
+
+            if ($valueContains) {
+                return true;
+            }
+
+        }
+
+        return false;
+    }
+
+    /**
+     * Determines if the user agent does not match any of the dictionaries.
+     *
+     * @param bool $exactMatch Whether to perform an exact match or not. Defaults to false.
+     * @param bool $caseSensitive Whether to perform a case-sensitive match. Defaults to false.
+     * @param bool $matchKey Whether to match on keys as well as values. Defaults to false.
+     * @return bool True if the user agent does not match any dictionary, false otherwise.
+     */
+    public function noMatch(bool $exactMatch = false, bool $caseSensitive = false, bool $matchKey = false): bool
+    {
+        return !$this->match($exactMatch, $caseSensitive, $matchKey);
+    }
+
+    /**
+     * Set the user agent string.
+     *
+     * @param string|null $userAgent The user agent string to be set. Defaults to null.
+     * @return UserAgentMatcher Returns the current UserAgent instance.
+     */
+    public function setUserAgent(?string $userAgent): UserAgentMatcher
+    {
+        $this->userAgent = $userAgent;
+
+        return $this;
+    }
+
+    /**
+     * Sets the dictionaries.
+     *
+     * @param array<int, LibraryInterface> $dictionaries An array of dictionaries.
+     * @return UserAgentMatcher The UserAgent object.
+     */
+    public function setDictionaries(array $dictionaries): UserAgentMatcher
+    {
+        $this->dictionaries = $dictionaries;
+
+        return $this;
+    }
+
+    /**
+     * Initialises the dictionaries used for matching the user agent.
+     *
+     * @throws InvalidArgumentException If no dictionaries have been set, or if a dictionary class does not implement
+     *                                  LibraryInterface.
+     */
+    protected function initialise(): void
+    {
+        if (empty($this->dictionaries)) {
+            throw new InvalidArgumentException('No dictionaries have been set');
+        }
+
+        foreach ($this->dictionaries as $key => $dictionary) {
+            if (is_string($dictionary)) {
+                if (class_exists($dictionary)) {
+                    $instance = new $dictionary();
+                    if ($instance instanceof LibraryInterface) {
+                        $this->dictionaries[$key] = $instance;
+                    } else {
+                        throw new InvalidArgumentException('The class ' . $dictionary . ' must implement ' . LibraryInterface::class);
+                    }
+                } else {
+                    throw new InvalidArgumentException('The class ' . $dictionary . ' could not be found');
+                }
+            } elseif (!$dictionary instanceof LibraryInterface) {
+                // If the dictionary is not a string and does not implement LibraryInterface, throw an exception
+                $name = is_object($dictionary) ? get_class($dictionary) : gettype($dictionary);
+                throw new InvalidArgumentException('The class ' . $name . ' must implement ' . LibraryInterface::class);
+            }
+        }
+    }
+}

--- a/tests/Network/Fixtures/TestDictionary.php
+++ b/tests/Network/Fixtures/TestDictionary.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Midnite81\Core\Tests\Network\Fixtures;
+
+class TestDictionary implements \Midnite81\Core\Contracts\Network\Libraries\LibraryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function dictionary(): \Illuminate\Support\Collection
+    {
+        return collect([
+            'ABC' => 'GHI',
+        ]);
+    }
+}

--- a/tests/Network/LibrariesTest.php
+++ b/tests/Network/LibrariesTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+it('implements Library interface and dictionary is a collection', function () {
+    expect($class = new \Midnite81\Core\Network\Libraries\Previewers())
+        ->toBeInstanceOf(\Midnite81\Core\Contracts\Network\Libraries\LibraryInterface::class)
+        ->and($class->dictionary())->toBeInstanceOf(\Illuminate\Support\Collection::class)
+        ->and($class = new \Midnite81\Core\Network\Libraries\SearchEngines())
+        ->toBeInstanceOf(\Midnite81\Core\Contracts\Network\Libraries\LibraryInterface::class)
+        ->and($class->dictionary())->toBeInstanceOf(\Illuminate\Support\Collection::class);
+
+});

--- a/tests/Network/UserAgentMatcherTest.php
+++ b/tests/Network/UserAgentMatcherTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+uses(\Midnite81\Core\Tests\CoreTestCase::class);
+
+use Midnite81\Core\Network\UserAgentMatcher;
+use Midnite81\Core\Tests\Network\Fixtures\TestDictionary;
+
+it('returns an error if no dictionaries are passed', function () {
+    $ua = new UserAgentMatcher();
+    expect(fn () => $ua->match())->toThrow(InvalidArgumentException::class, 'No dictionaries have been set');
+});
+
+it('returns an error if no dictionaries are not instance of Library Interface', function () {
+    expect(fn () => (new UserAgentMatcher(null, ['test']))->match())
+        ->toThrow(InvalidArgumentException::class, 'The class test could not be found')
+        ->and(fn () => (new UserAgentMatcher(null, [new stdClass()]))->match())
+        ->toThrow(InvalidArgumentException::class, 'The class stdClass must implement Midnite81\Core\Contracts\Network\Libraries\LibraryInterface')
+        ->and(fn () => (new UserAgentMatcher(null, [new UserAgentMatcher()]))->match())
+        ->toThrow(InvalidArgumentException::class, 'The class Midnite81\Core\Network\UserAgentMatcher must implement Midnite81\Core\Contracts\Network\Libraries\LibraryInt');
+});
+
+it('instantiates the dictionary when passed as a string class', function () {
+    $ua = new UserAgentMatcher(userAgent: 'testing ghi', dictionaries: [TestDictionary::class]);
+    expect($ua->match())->toBeTrue();
+});
+
+it('returns true if the user agent is part of any value in the dictionaries', function () {
+    $ua = new UserAgentMatcher(
+        'Testing ghi123',
+        [new TestDictionary()]
+    );
+    expect($ua->match())->toBeTrue();
+});
+
+it('returns true if the user agent matches exactly with a dictionary value', function () {
+    $ua = new UserAgentMatcher(
+        'ghi',
+        [new TestDictionary()]
+    );
+    expect($ua->match(exactMatch: true))->toBeTrue();
+});
+
+it('returns false if the user agent does not match exactly with a dictionary value', function () {
+    $ua = new UserAgentMatcher(
+        'ghi 123',
+        [new TestDictionary()]
+    );
+    expect($ua->match(exactMatch: true))->toBeFalse();
+});
+
+it('returns false if the user agent does not match any value in the dictionaries', function () {
+    $ua = new UserAgentMatcher(
+        'Testing 123',
+        [new TestDictionary()]
+    );
+    expect($ua->match())->toBeFalse();
+});
+
+it('returns true if the user agent matches a key in the dictionary', function () {
+    $ua = new UserAgentMatcher(
+        'abc123',
+        [new TestDictionary()]
+    );
+    expect($ua->match(matchKey: true))->toBeTrue();
+});
+
+it('returns true if the user agent matches a key in the dictionary if exact match', function () {
+    $ua = new UserAgentMatcher(
+        'abc',
+        [new TestDictionary()]
+    );
+    expect($ua->match(exactMatch: true, matchKey: true))->toBeTrue();
+});
+
+it('returns false if the user agent does not match a key in the dictionary', function () {
+    $ua = new UserAgentMatcher(
+        'abc 123',
+        [new TestDictionary()]
+    );
+    expect($ua->match(exactMatch: true, matchKey: true))->toBeFalse();
+});
+
+it('returns true when given a user agent that matches a dictionary value', function () {
+    $ua = new UserAgentMatcher();
+    $ua->setUserAgent('ghi123');
+    $ua->setDictionaries([new TestDictionary()]);
+    expect($ua->match())->toBeTrue();
+});
+
+it('returns true when no match is found', function () {
+    $ua = new UserAgentMatcher(
+        'xyz',
+        [new TestDictionary()]
+    );
+    expect($ua->noMatch())->toBeTrue();
+});
+
+it('returns false when a match is found', function () {
+    $ua = new UserAgentMatcher(
+        'ghi',
+        [new TestDictionary()]
+    );
+    expect($ua->noMatch())->toBeFalse();
+});
+
+it('returns false when an exact match is found', function () {
+    $ua = new UserAgentMatcher(
+        'GHI',
+        [new TestDictionary()]
+    );
+    expect($ua->noMatch(exactMatch: true))->toBeFalse();
+});
+
+it('returns true when matched case sensitively', function () {
+    $ua = new UserAgentMatcher(
+        'GHI',
+        [new TestDictionary()]
+    );
+
+    expect($ua->match(caseSensitive: true))->toBeTrue();
+});
+
+it('returns false when no match is found case sensitively', function () {
+    $ua = new UserAgentMatcher(
+        'ghi',
+        [new TestDictionary()]
+    );
+
+    expect($ua->match(caseSensitive: true))->toBeFalse();
+});
+
+it('returns false when no match on key is found case sensitively', function () {
+    $ua = new UserAgentMatcher(
+        'abc',
+        [new TestDictionary()]
+    );
+
+    expect($ua->match(caseSensitive: true, matchKey: true))->toBeFalse();
+});


### PR DESCRIPTION
Implemented two new Network Libraries: Previewers and SearchEngines, which include their respective test files. Also added a LibraryInterface to establish a contract for these new libraries. The addition of these libraries will enable recognition and handling of different web crawlers and bots in user agent strings.