### PR TITLE
Add `toDeepArray` function for recursive data conversion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
             "src/Functions/first.php",
             "src/Functions/enum.php",
             "src/Functions/time-conversion.php",
+            "src/Functions/array-converstion.php",
             "helper.php"
         ]
     },

--- a/src/Functions/array-converstion.php
+++ b/src/Functions/array-converstion.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Midnite81\Core\Functions;
+
+/**
+ * Recursively converts a value to a deep array.
+ *
+ * @param mixed $value The value to convert.
+ * @return mixed The converted value.
+ */
+function toDeepArray(mixed $value): mixed
+{
+    if (is_array($value)) {
+        return array_map(fn($item) => toDeepArray($item), $value);
+    }
+
+    if ($value instanceof \Illuminate\Support\Collection) {
+        return $value->map(fn($item) => toDeepArray($item))->toArray();
+    }
+
+    if ($value instanceof \Illuminate\Contracts\Support\Arrayable) {
+        return toDeepArray($value->toArray());
+    }
+
+    return $value;
+}

--- a/src/Functions/array-converstion.php
+++ b/src/Functions/array-converstion.php
@@ -13,11 +13,11 @@ namespace Midnite81\Core\Functions;
 function toDeepArray(mixed $value): mixed
 {
     if (is_array($value)) {
-        return array_map(fn($item) => toDeepArray($item), $value);
+        return array_map(fn ($item) => toDeepArray($item), $value);
     }
 
     if ($value instanceof \Illuminate\Support\Collection) {
-        return $value->map(fn($item) => toDeepArray($item))->toArray();
+        return $value->map(fn ($item) => toDeepArray($item))->toArray();
     }
 
     if ($value instanceof \Illuminate\Contracts\Support\Arrayable) {

--- a/tests/Functions/array-conversation-test.php
+++ b/tests/Functions/array-conversation-test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Contracts\Support\Arrayable;
 use Midnite81\Core\Tests\CoreTestCase;
+
 use function Midnite81\Core\Functions\toDeepArray;
 
 uses(CoreTestCase::class);
@@ -26,9 +27,9 @@ it('handles nested arrays', function () {
         'a' => 1,
         'b' => [
             'c' => 3,
-            'd' => 4
+            'd' => 4,
         ],
-        'e' => 5
+        'e' => 5,
     ];
 
     // Act
@@ -57,7 +58,7 @@ it('handles nested collections', function () {
     $collection = collect([
         'a' => 1,
         'b' => collect(['c' => 3, 'd' => 4]),
-        'e' => 5
+        'e' => 5,
     ]);
 
     // Act
@@ -67,7 +68,7 @@ it('handles nested collections', function () {
     $expected = [
         'a' => 1,
         'b' => ['c' => 3, 'd' => 4],
-        'e' => 5
+        'e' => 5,
     ];
     expect($result)->toBe($expected);
     expect($result)->toBeArray();
@@ -76,7 +77,8 @@ it('handles nested collections', function () {
 
 it('handles arrayable objects', function () {
     // Arrange
-    $arrayable = new class implements Arrayable {
+    $arrayable = new class implements Arrayable
+    {
         public function toArray(): array
         {
             return ['a' => 1, 'b' => 2, 'c' => 3];
@@ -93,7 +95,8 @@ it('handles arrayable objects', function () {
 
 it('handles complex nested structures', function () {
     // Arrange
-    $arrayable = new class implements Arrayable {
+    $arrayable = new class implements Arrayable
+    {
         public function toArray(): array
         {
             return ['x' => 10, 'y' => 20];
@@ -105,12 +108,12 @@ it('handles complex nested structures', function () {
         'b' => collect([
             'c' => 3,
             'd' => $arrayable,
-            'e' => collect(['f' => 6])
+            'e' => collect(['f' => 6]),
         ]),
         'g' => [
             'h' => 8,
-            'i' => collect(['j' => 9])
-        ]
+            'i' => collect(['j' => 9]),
+        ],
     ];
 
     // Act
@@ -122,12 +125,12 @@ it('handles complex nested structures', function () {
         'b' => [
             'c' => 3,
             'd' => ['x' => 10, 'y' => 20],
-            'e' => ['f' => 6]
+            'e' => ['f' => 6],
         ],
         'g' => [
             'h' => 8,
-            'i' => ['j' => 9]
-        ]
+            'i' => ['j' => 9],
+        ],
     ];
 
     expect($result)->toBe($expected);
@@ -156,4 +159,3 @@ it('keeps scalar values untouched', function () {
     // Test with null
     expect(toDeepArray(null))->toBeNull();
 });
-

--- a/tests/Functions/array-conversation-test.php
+++ b/tests/Functions/array-conversation-test.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Support\Arrayable;
+use Midnite81\Core\Tests\CoreTestCase;
+use function Midnite81\Core\Functions\toDeepArray;
+
+uses(CoreTestCase::class);
+
+it('handles simple arrays', function () {
+    // Arrange
+    $input = ['a' => 1, 'b' => 2, 'c' => 3];
+
+    // Act
+    $result = toDeepArray($input);
+
+    // Assert
+    expect($result)->toBe($input)
+        ->and($result)->toBeArray();
+});
+
+it('handles nested arrays', function () {
+    // Arrange
+    $input = [
+        'a' => 1,
+        'b' => [
+            'c' => 3,
+            'd' => 4
+        ],
+        'e' => 5
+    ];
+
+    // Act
+    $result = toDeepArray($input);
+
+    // Assert
+    expect($result)->toBe($input);
+    expect($result)->toBeArray();
+    expect($result['b'])->toBeArray();
+});
+
+it('handles collections', function () {
+    // Arrange
+    $collection = collect(['a' => 1, 'b' => 2, 'c' => 3]);
+
+    // Act
+    $result = toDeepArray($collection);
+
+    // Assert
+    expect($result)->toBe(['a' => 1, 'b' => 2, 'c' => 3]);
+    expect($result)->toBeArray();
+});
+
+it('handles nested collections', function () {
+    // Arrange
+    $collection = collect([
+        'a' => 1,
+        'b' => collect(['c' => 3, 'd' => 4]),
+        'e' => 5
+    ]);
+
+    // Act
+    $result = toDeepArray($collection);
+
+    // Assert
+    $expected = [
+        'a' => 1,
+        'b' => ['c' => 3, 'd' => 4],
+        'e' => 5
+    ];
+    expect($result)->toBe($expected);
+    expect($result)->toBeArray();
+    expect($result['b'])->toBeArray();
+});
+
+it('handles arrayable objects', function () {
+    // Arrange
+    $arrayable = new class implements Arrayable {
+        public function toArray(): array
+        {
+            return ['a' => 1, 'b' => 2, 'c' => 3];
+        }
+    };
+
+    // Act
+    $result = toDeepArray($arrayable);
+
+    // Assert
+    expect($result)->toBe(['a' => 1, 'b' => 2, 'c' => 3]);
+    expect($result)->toBeArray();
+});
+
+it('handles complex nested structures', function () {
+    // Arrange
+    $arrayable = new class implements Arrayable {
+        public function toArray(): array
+        {
+            return ['x' => 10, 'y' => 20];
+        }
+    };
+
+    $complex = [
+        'a' => 1,
+        'b' => collect([
+            'c' => 3,
+            'd' => $arrayable,
+            'e' => collect(['f' => 6])
+        ]),
+        'g' => [
+            'h' => 8,
+            'i' => collect(['j' => 9])
+        ]
+    ];
+
+    // Act
+    $result = toDeepArray($complex);
+
+    // Assert
+    $expected = [
+        'a' => 1,
+        'b' => [
+            'c' => 3,
+            'd' => ['x' => 10, 'y' => 20],
+            'e' => ['f' => 6]
+        ],
+        'g' => [
+            'h' => 8,
+            'i' => ['j' => 9]
+        ]
+    ];
+
+    expect($result)->toBe($expected);
+    expect($result)->toBeArray();
+    expect($result['b'])->toBeArray();
+    expect($result['b']['d'])->toBeArray();
+    expect($result['b']['e'])->toBeArray();
+    expect($result['g'])->toBeArray();
+    expect($result['g']['i'])->toBeArray();
+});
+
+it('keeps scalar values untouched', function () {
+    // Test with string
+    expect(toDeepArray('test'))->toBe('test');
+
+    // Test with integer
+    expect(toDeepArray(123))->toBe(123);
+
+    // Test with float
+    expect(toDeepArray(123.45))->toBe(123.45);
+
+    // Test with boolean
+    expect(toDeepArray(true))->toBeTrue();
+    expect(toDeepArray(false))->toBeFalse();
+
+    // Test with null
+    expect(toDeepArray(null))->toBeNull();
+});
+


### PR DESCRIPTION
### Description of changes
- Implemented the `toDeepArray` function to convert various data types (arrays, collections, arrayable objects) into deep arrays.
- Included test coverage for nested structures, scalar values, and edge cases to ensure reliability.
- Updated `composer.json` file to register the new functionality.

### Checklist
- [ ] Tests written and verified
- [ ] Documentation updated if applicable
- [ ] Code builds without errors
- [ ] Follows the coding standards and conventions