### PR TITLE
Add CollectionOf support for entity hydration

### DIFF
--- a/src/Attributes/CollectionOf.php
+++ b/src/Attributes/CollectionOf.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Midnite81\Core\Attributes;
+
+use Attribute;
+
+/**
+ * The CollectionOf attribute is used to specify that a class property should be treated as a
+ * collection containing instances of a specific class when using BaseEntity hydration.
+ *
+ * Example usage:
+ * #[CollectionOf(\Namespace\To\YourClass::class)]
+ * public Collection $yourProperty;
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class CollectionOf
+{
+    public function __construct(public string $class) {}
+}

--- a/src/Entities/Concerns/PropertyHydration.php
+++ b/src/Entities/Concerns/PropertyHydration.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Midnite81\Core\Entities\Concerns;
 
 use Carbon\Carbon;
+use Illuminate\Support\Collection;
 use Midnite81\Core\Exceptions\PropertyMappingException;
 use ReflectionClass;
 
@@ -105,6 +106,23 @@ trait PropertyHydration
                         // Assumes the class has a constructor that can accept the data for each item
                         return new $className($item);
                     }, $data[$sourceName]);
+                }
+
+                continue; // Proceed to the next property after handling
+            }
+
+            // Handle properties with the CollectionOf attribute
+            $collectionOfAttributes = $property->getAttributes(\Midnite81\Core\Attributes\CollectionOf::class);
+            if (!empty($collectionOfAttributes)) {
+                $attributeInstance = $collectionOfAttributes[0]->newInstance();
+                $className = $attributeInstance->class;
+                $items = $data[$sourceName];
+
+                if ($items instanceof Collection) {
+                    $this->$name = $items->map(fn ($item) => new $className($item));
+                } elseif (is_array($items)) {
+                    $this->$name = Collection::make($items)
+                        ->map(fn ($item) => new $className($item));
                 }
 
                 continue; // Proceed to the next property after handling

--- a/tests/Entities/AutoMappingTest.php
+++ b/tests/Entities/AutoMappingTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Collection;
 use Midnite81\Core\Tests\Entities\TestHelpers\AutoMapping\Account;
 
 it('can auto-map', function () {
@@ -27,6 +28,16 @@ it('can auto-map', function () {
                 'orderDate' => '2021-01-02',
             ],
         ],
+        'orderCollection' => Collection::make([
+            [
+                'orderNumber' => '123458',
+                'orderDate' => '2021-01-03',
+            ],
+            [
+                'orderNumber' => '123459',
+                'orderDate' => '2021-01-04',
+            ],
+        ]),
         'accountIdentifier' => '5caea84d-4a93-4eda-99c0-825178b39726',
     ];
 
@@ -46,6 +57,12 @@ it('can auto-map', function () {
         ->and($account->orders[0]->orderDate->format('Y-m-d'))->toBe('2021-01-01')
         ->and($account->orders[1]->orderNumber)->toBe('123457')
         ->and($account->orders[1]->orderDate->format('Y-m-d'))->toBe('2021-01-02')
+        ->and($account->orderCollection)->toBeInstanceOf(Collection::class)
+        ->and($account->orderCollection)->toHaveCount(2)
+        ->and($account->orderCollection[0]->orderNumber)->toBe('123458')
+        ->and($account->orderCollection[0]->orderDate->format('Y-m-d'))->toBe('2021-01-03')
+        ->and($account->orderCollection[1]->orderNumber)->toBe('123459')
+        ->and($account->orderCollection[1]->orderDate->format('Y-m-d'))->toBe('2021-01-04')
         ->and($account->uniqueIdentifier)->toBe('5caea84d-4a93-4eda-99c0-825178b39726');
 });
 
@@ -72,6 +89,16 @@ it('can auto-map stdClass', function () {
                 'orderDate' => '2021-01-02',
             ],
         ],
+        'orderCollection' => [
+            [
+                'orderNumber' => '123458',
+                'orderDate' => '2021-01-03',
+            ],
+            [
+                'orderNumber' => '123459',
+                'orderDate' => '2021-01-04',
+            ],
+        ],
         'accountIdentifier' => '5caea84d-4a93-4eda-99c0-825178b39726',
     ];
 
@@ -91,5 +118,11 @@ it('can auto-map stdClass', function () {
         ->and($account->orders[0]->orderDate->format('Y-m-d'))->toBe('2021-01-01')
         ->and($account->orders[1]->orderNumber)->toBe('123457')
         ->and($account->orders[1]->orderDate->format('Y-m-d'))->toBe('2021-01-02')
+        ->and($account->orderCollection)->toBeInstanceOf(Collection::class)
+        ->and($account->orderCollection)->toHaveCount(2)
+        ->and($account->orderCollection[0]->orderNumber)->toBe('123458')
+        ->and($account->orderCollection[0]->orderDate->format('Y-m-d'))->toBe('2021-01-03')
+        ->and($account->orderCollection[1]->orderNumber)->toBe('123459')
+        ->and($account->orderCollection[1]->orderDate->format('Y-m-d'))->toBe('2021-01-04')
         ->and($account->uniqueIdentifier)->toBe('5caea84d-4a93-4eda-99c0-825178b39726');
 });

--- a/tests/Entities/TestHelpers/AutoMapping/Account.php
+++ b/tests/Entities/TestHelpers/AutoMapping/Account.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Midnite81\Core\Tests\Entities\TestHelpers\AutoMapping;
 
+use Illuminate\Support\Collection;
 use Midnite81\Core\Attributes\ArrayOf;
+use Midnite81\Core\Attributes\CollectionOf;
 use Midnite81\Core\Attributes\PropertyName;
 use Midnite81\Core\Attributes\SourceName;
 use Midnite81\Core\Entities\BaseEntity;
@@ -29,6 +31,12 @@ class Account extends BaseEntity
      */
     #[ArrayOf(Orders::class)]
     public array $orders;
+
+    /**
+     * @var Collection<int, Orders>
+     */
+    #[CollectionOf(Orders::class)]
+    public Collection $orderCollection;
 
     /**
      * @param array|object $data


### PR DESCRIPTION
## Summary
- add a new `CollectionOf` attribute for `BaseEntity` properties that should hydrate into an `Illuminate\Support\Collection`
- extend property hydration to build typed collections from either arrays or existing collections in the source data
- add auto-mapping test coverage for collection-backed entity properties alongside existing `ArrayOf` behavior

## Testing
- `vendor/bin/pest tests/Entities/AutoMappingTest.php`