### PR TITLE
Add trim string mapping attributes

### DIFF
--- a/docs/Attributes.md
+++ b/docs/Attributes.md
@@ -75,3 +75,29 @@ This attribute ensures that a property has been initialized, as it is required, 
 protected string $name;
 ```
 
+## TrimString Attribute
+
+**Usage:** Used with `BaseEntity`  
+**Target:** Properties
+
+This attribute trims leading and trailing whitespace from a mapped string value before property handlers and type
+handlers are applied.
+
+```php
+#[\Midnite81\Core\Attributes\TrimString]
+protected string $name;
+```
+
+## TrimStrings Attribute
+
+**Usage:** Used with `BaseEntity`  
+**Target:** Classes
+
+This attribute applies the same trimming behavior as `TrimString`, but to every mapped property in the class.
+
+```php
+#[\Midnite81\Core\Attributes\TrimStrings]
+class MyEntity
+{
+}
+```

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,13 @@ This package contains;
   - [ValidationHandler](docs/Handlers/ValidationHandler.md)
   - [ValidationExceptionBuilder](docs/Validation/ValidationExceptionBuilder.md))
 
+## Attribute Highlights
+
+For full attribute usage and examples, see [Attributes](docs/Attributes.md).
+
+- `#[TrimString]` trims a mapped string value for a single property before property handlers and type handlers run.
+- `#[TrimStrings]` applies the same trimming behaviour to all mapped string properties on a class.
+
 ## Installation
 
 This package requires PHP 8.1+ and has a Laravel Service Provider, which is auto-registered.

--- a/src/Attributes/TrimString.php
+++ b/src/Attributes/TrimString.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Midnite81\Core\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class TrimString {}

--- a/src/Attributes/TrimStrings.php
+++ b/src/Attributes/TrimStrings.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Midnite81\Core\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class TrimStrings {}

--- a/src/Entities/Concerns/PropertyHydration.php
+++ b/src/Entities/Concerns/PropertyHydration.php
@@ -7,6 +7,7 @@ namespace Midnite81\Core\Entities\Concerns;
 use Carbon\Carbon;
 use Midnite81\Core\Exceptions\PropertyMappingException;
 use ReflectionClass;
+use ReflectionProperty;
 
 trait PropertyHydration
 {
@@ -82,6 +83,8 @@ trait PropertyHydration
         }
 
         $reflection = new ReflectionClass($this);
+        $trimAllStrings = !empty($reflection->getAttributes(\Midnite81\Core\Attributes\TrimStrings::class));
+
         foreach ($reflection->getProperties() as $property) {
             $attributes = $property->getAttributes(\Midnite81\Core\Attributes\SourceName::class);
             $sourceNameAttribute = !empty($attributes) ? $attributes[0]->newInstance() : null;
@@ -93,6 +96,11 @@ trait PropertyHydration
             }
 
             $name = $property->getName();
+            $value = $this->trimMappedValue(
+                $data[$sourceName],
+                $property,
+                $trimAllStrings,
+            );
 
             // Handle properties with the ArrayOf attribute
             $arrayOfAttributes = $property->getAttributes(\Midnite81\Core\Attributes\ArrayOf::class);
@@ -100,11 +108,11 @@ trait PropertyHydration
                 $attributeInstance = $arrayOfAttributes[0]->newInstance();
                 $className = $attributeInstance->class;
 
-                if (is_array($data[$sourceName])) {
+                if (is_array($value)) {
                     $this->$name = array_map(function ($item) use ($className) {
                         // Assumes the class has a constructor that can accept the data for each item
                         return new $className($item);
-                    }, $data[$sourceName]);
+                    }, $value);
                 }
 
                 continue; // Proceed to the next property after handling
@@ -112,7 +120,7 @@ trait PropertyHydration
 
             // Check for a custom property handler
             if (isset($this->propertyHandlers[$name])) {
-                $this->$name = call_user_func($this->propertyHandlers[$name], $data[$sourceName]);
+                $this->$name = call_user_func($this->propertyHandlers[$name], $value);
 
                 continue;
             }
@@ -121,7 +129,7 @@ trait PropertyHydration
             $type = $property->getType();
             if (!$type) {
                 // Direct assignment if the property has no type
-                $this->$name = $data[$sourceName];
+                $this->$name = $value;
 
                 continue;
             }
@@ -129,11 +137,27 @@ trait PropertyHydration
             $typeName = $type->getName();
             if (isset($this->typeHandlers[$typeName])) {
                 // Use a type handler if defined
-                $this->$name = call_user_func($this->typeHandlers[$typeName], $data[$sourceName]);
+                $this->$name = call_user_func($this->typeHandlers[$typeName], $value);
             } else {
                 // Direct assignment as a fallback
-                $this->$name = $data[$sourceName];
+                $this->$name = $value;
             }
         }
+    }
+
+    protected function trimMappedValue(
+        mixed $value,
+        ReflectionProperty $property,
+        bool $trimAllStrings,
+    ): mixed {
+        if (!is_string($value)) {
+            return $value;
+        }
+
+        if ($trimAllStrings || !empty($property->getAttributes(\Midnite81\Core\Attributes\TrimString::class))) {
+            return trim($value);
+        }
+
+        return $value;
     }
 }

--- a/tests/Attributes/TrimStringTest.php
+++ b/tests/Attributes/TrimStringTest.php
@@ -1,0 +1,8 @@
+<?php
+
+it('initializes the class', function () {
+    $sut = new \Midnite81\Core\Attributes\TrimString;
+
+    expect($sut)
+        ->toBeInstanceOf(\Midnite81\Core\Attributes\TrimString::class);
+});

--- a/tests/Attributes/TrimStringsTest.php
+++ b/tests/Attributes/TrimStringsTest.php
@@ -1,0 +1,8 @@
+<?php
+
+it('initializes the class', function () {
+    $sut = new \Midnite81\Core\Attributes\TrimStrings;
+
+    expect($sut)
+        ->toBeInstanceOf(\Midnite81\Core\Attributes\TrimStrings::class);
+});

--- a/tests/Entities/AutoMappingTest.php
+++ b/tests/Entities/AutoMappingTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Midnite81\Core\Tests\Entities\TestHelpers\AutoMapping\Account;
+use Midnite81\Core\Tests\Entities\TestHelpers\AutoMapping\TrimmedClassEntity;
+use Midnite81\Core\Tests\Entities\TestHelpers\AutoMapping\TrimmedPropertyEntity;
 
 it('can auto-map', function () {
     $data = [
@@ -92,4 +94,24 @@ it('can auto-map stdClass', function () {
         ->and($account->orders[1]->orderNumber)->toBe('123457')
         ->and($account->orders[1]->orderDate->format('Y-m-d'))->toBe('2021-01-02')
         ->and($account->uniqueIdentifier)->toBe('5caea84d-4a93-4eda-99c0-825178b39726');
+});
+
+it('can trim a mapped property marked with trim string', function () {
+    $entity = new TrimmedPropertyEntity([
+        'trimmed' => '  keep me tidy  ',
+        'untouched' => '  leave me alone  ',
+    ]);
+
+    expect($entity->trimmed)->toBe('keep me tidy')
+        ->and($entity->untouched)->toBe('  leave me alone  ');
+});
+
+it('can trim all mapped string properties from a class attribute', function () {
+    $entity = new TrimmedClassEntity([
+        'trimmed' => '  tidy me  ',
+        'upperCaseString' => '  make me loud  ',
+    ]);
+
+    expect($entity->trimmed)->toBe('tidy me')
+        ->and($entity->upperCaseString)->toBe('MAKE ME LOUD');
 });

--- a/tests/Entities/TestHelpers/AutoMapping/TrimmedClassEntity.php
+++ b/tests/Entities/TestHelpers/AutoMapping/TrimmedClassEntity.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Midnite81\Core\Tests\Entities\TestHelpers\AutoMapping;
+
+use Midnite81\Core\Attributes\TrimStrings;
+use Midnite81\Core\Entities\BaseEntity;
+use Midnite81\Core\Exceptions\PropertyMappingException;
+
+#[TrimStrings]
+class TrimmedClassEntity extends BaseEntity
+{
+    public string $trimmed;
+
+    public string $upperCaseString;
+
+    /**
+     * @param array|object $data
+     *
+     * @throws PropertyMappingException
+     */
+    public function __construct(array|object $data = [])
+    {
+        parent::__construct();
+        $this->mapProperties($data);
+    }
+
+    public function definePropertyHandlers(): void
+    {
+        $this->propertyHandlers = [
+            'upperCaseString' => fn ($value) => strtoupper($value),
+        ];
+    }
+}

--- a/tests/Entities/TestHelpers/AutoMapping/TrimmedPropertyEntity.php
+++ b/tests/Entities/TestHelpers/AutoMapping/TrimmedPropertyEntity.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Midnite81\Core\Tests\Entities\TestHelpers\AutoMapping;
+
+use Midnite81\Core\Attributes\TrimString;
+use Midnite81\Core\Entities\BaseEntity;
+use Midnite81\Core\Exceptions\PropertyMappingException;
+
+class TrimmedPropertyEntity extends BaseEntity
+{
+    #[TrimString]
+    public string $trimmed;
+
+    public string $untouched;
+
+    /**
+     * @param array|object $data
+     *
+     * @throws PropertyMappingException
+     */
+    public function __construct(array|object $data = [])
+    {
+        parent::__construct();
+        $this->mapProperties($data);
+    }
+}


### PR DESCRIPTION
## Summary
- add `#[TrimString]` for property-level trimming during entity mapping
- add `#[TrimStrings]` for class-level trimming across all mapped string properties
- document the new attributes in the attributes guide and surface them from the main README

## Implementation details
- update `PropertyHydration` to trim inbound mapped values before custom property handlers and type handlers run
- keep trimming limited to string inputs so non-string mapped values continue to hydrate unchanged
- add focused helper entities to verify property-level and class-level behaviour in the auto-mapping test suite

## Testing
- `vendor/bin/pest tests/Attributes/TrimStringTest.php tests/Attributes/TrimStringsTest.php tests/Entities/AutoMappingTest.php`

## Notes
- commit hook prefixes commit messages with the current branch name in this repository, so the pushed commit includes that automatic prefix