### PR TITLE
Fix HasUuid boot method and preserve preset UUIDs

### DIFF
--- a/src/Traits/Eloquent/HasUuid.php
+++ b/src/Traits/Eloquent/HasUuid.php
@@ -14,11 +14,11 @@ trait HasUuid
      * This method is called automatically when the trait is being used by a model.
      * It registers a "creating" event that generates a UUID and assigns it to the specified column.
      */
-    public static function bootHasUUID(): void
+    public static function bootHasUuid(): void
     {
-        static::creating(function ($model) {
+        static::creating(function ($model): void {
             $column = $model->getUuidColumn();
-            $model->$column = uuid();
+            $model->$column ??= uuid();
         });
     }
 

--- a/tests/Traits/Eloquent/HasUuidTest.php
+++ b/tests/Traits/Eloquent/HasUuidTest.php
@@ -12,7 +12,7 @@ test('it generates a UUID on creating', function () {
     };
 
     // Simulate the "creating" event
-    $model->bootHasUUID();
+    $model->bootHasUuid();
 
     expect($model)->toBeInstanceOf(Model::class);
 });


### PR DESCRIPTION
## Summary
- align the trait boot method name with Laravel's expected HasUuid convention
- preserve preassigned UUID values instead of overwriting them during model creation
- update the trait test to call the corrected boot method

## Testing
- ./vendor/bin/pest tests/Traits/Eloquent/HasUuidTest.php